### PR TITLE
UHF-10519-add-missing-module

### DIFF
--- a/conf/cmi/block.block.surveys.yml
+++ b/conf/cmi/block.block.surveys.yml
@@ -1,0 +1,21 @@
+uuid: ec6962ac-fb1a-48b6-908e-923ba61f44c3
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_etusivu_entities
+  theme:
+    - hdbt_subtheme
+id: surveys
+theme: hdbt_subtheme
+region: before_content
+weight: -15
+provider: helfi_node_survey
+plugin: surveys
+settings:
+  id: surveys
+  label: Surveys
+  label_display: ''
+  provider: helfi_node_survey
+  use_remote_entities: true
+visibility: {  }

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -42,6 +42,7 @@ module:
   helfi_ckeditor: 0
   helfi_emergency_config: 0
   helfi_emergency_general: 0
+  helfi_etusivu_entities: 0
   helfi_eu_cookie_compliance: 0
   helfi_image_styles: 0
   helfi_media: 0

--- a/conf/cmi/external_entities.external_entity_type.helfi_announcements.yml
+++ b/conf/cmi/external_entities.external_entity_type.helfi_announcements.yml
@@ -1,0 +1,48 @@
+uuid: 072df4c4-3de5-44f9-bd4f-c1d09006ce88
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: klULx3zqlYgz7OOfeGsjBYHQmFp8V6_aMlFUYaOQRmA
+id: helfi_announcements
+label: 'Helfi: Announcements'
+label_plural: 'Helfi: Announcements'
+description: ''
+generate_aliases: null
+read_only: true
+field_mapper_id: jsonpath
+field_mapper_config:
+  field_mappings:
+    id:
+      value: $.id
+    uuid:
+      value: $.id
+    title:
+      value: '$.attributes["title"]'
+    published_at:
+      value: '$.attributes["published_at"]'
+    unpublish_on:
+      value: '$.attributes["unpublish_on"]'
+    notification:
+      value: '$.attributes["notification"]'
+    langcode:
+      value: '$.attributes["langcode"]'
+    body:
+      value: '$.attributes["body"]["value"]'
+    status:
+      value: '$.attributes["status"]'
+    announcement_type:
+      value: '$.attributes["field_announcement_type"]'
+    announcement_link_text:
+      value: '$.attributes["field_announcement_link"]["title"]'
+    announcement_link_url:
+      value: '$.attributes["field_announcement_link"]["uri"]'
+    announcement_assistive_technology_close_button_title:
+      value: '$.attributes["field_announcement_title"]'
+storage_client_id: helfi_announcements
+storage_client_config: {  }
+persistent_cache_max_age: -1
+annotation_entity_type_id: null
+annotation_bundle_id: null
+annotation_field_name: null
+inherits_annotation_fields: false

--- a/conf/cmi/external_entities.external_entity_type.helfi_surveys.yml
+++ b/conf/cmi/external_entities.external_entity_type.helfi_surveys.yml
@@ -1,0 +1,42 @@
+uuid: be631905-d77b-418a-890e-b04fa3ed3e22
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: _EBh68cyUNEhZdqfsN5IEH5ieC-ND8JOMk5t_uhXdJc
+id: helfi_surveys
+label: 'Helfi: Survey'
+label_plural: 'Helfi: Surveys'
+description: ''
+generate_aliases: null
+read_only: true
+field_mapper_id: jsonpath
+field_mapper_config:
+  field_mappings:
+    id:
+      value: $.id
+    uuid:
+      value: $.id
+    title:
+      value: '$.attributes["title"]'
+    published_at:
+      value: '$.attributes["published_at"]'
+    unpublish_on:
+      value: '$.attributes["unpublish_on"]'
+    langcode:
+      value: '$.attributes["langcode"]'
+    body:
+      value: '$.attributes["body"]["value"]'
+    status:
+      value: '$.attributes["status"]'
+    survey_link_text:
+      value: '$.attributes["field_survey_link"]["title"]'
+    survey_link_url:
+      value: '$.attributes["field_survey_link"]["uri"]'
+storage_client_id: helfi_surveys
+storage_client_config: {  }
+persistent_cache_max_age: -1
+annotation_entity_type_id: null
+annotation_bundle_id: null
+annotation_field_name: null
+inherits_annotation_fields: false

--- a/conf/cmi/user.role.anonymous.yml
+++ b/conf/cmi/user.role.anonymous.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - eu_cookie_compliance
+    - external_entities
     - helfi_api_base
     - media
     - system
@@ -16,5 +17,7 @@ is_admin: false
 permissions:
   - 'access content'
   - 'display eu cookie compliance popup'
+  - 'view helfi_announcements external entity'
+  - 'view helfi_surveys external entity'
   - 'view media'
   - 'view remote entities'

--- a/conf/cmi/user.role.authenticated.yml
+++ b/conf/cmi/user.role.authenticated.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - eu_cookie_compliance
+    - external_entities
     - file
     - helfi_api_base
     - media
@@ -21,6 +22,8 @@ permissions:
   - 'access toolbar'
   - 'delete own files'
   - 'display eu cookie compliance popup'
+  - 'view helfi_announcements external entity'
+  - 'view helfi_surveys external entity'
   - 'view media'
   - 'view remote entities'
   - 'view unpublished paragraphs'


### PR DESCRIPTION
Add missing `helfi_etusivu_entities` which is required for announcements block.