### PR TITLE
UHF-10625: Enable helfi_azure_fs module

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -38,6 +38,7 @@ module:
   hdbt_admin_tools: 0
   health_check: 0
   helfi_api_base: 0
+  helfi_azure_fs: 0
   helfi_base_content: 0
   helfi_ckeditor: 0
   helfi_emergency_config: 0


### PR DESCRIPTION
# [UHF-10625](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10625)

## What was done

This PR enables helfi_azure_fs module. Should help with filesystem permission issues.

## Other PRs
- https://github.com/City-of-Helsinki/drupal-palvelukeskus/pull/60
- https://github.com/City-of-Helsinki/helsinki-paatokset/pull/464

[UHF-10625]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ