### PR TITLE
UHF-10521: Enable 2FA on Emergency site

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -23,6 +23,7 @@ module:
   easy_breadcrumb: 0
   editor: 0
   editoria11y: 0
+  encrypt: 0
   entity: 0
   entity_reference_revisions: 0
   entity_usage: 0
@@ -77,6 +78,7 @@ module:
   helfi_platform_config_base: 0
   helfi_react_search: 0
   helfi_static_trigger: 0
+  helfi_tfa: 0
   helfi_user_roles: 0
   helfi_users: 0
   help: 0
@@ -86,6 +88,7 @@ module:
   imagemagick: 0
   jquery_ui: 0
   jquery_ui_draggable: 0
+  key: 0
   language: 0
   link: 0
   linkit: 0
@@ -113,6 +116,7 @@ module:
   phpass: 0
   raven: 0
   readonly_field_widget: 0
+  real_aes: 0
   redirect: 0
   responsive_image: 0
   rest: 0
@@ -129,6 +133,7 @@ module:
   taxonomy: 0
   telephone: 0
   text: 0
+  tfa: 0
   token: 0
   toolbar: 0
   twig_tweak: 0

--- a/conf/cmi/encrypt.profile.real_aes.yml
+++ b/conf/cmi/encrypt.profile.real_aes.yml
@@ -1,0 +1,15 @@
+uuid: 90d7b880-aa02-4cff-aeb9-69e03db7a21b
+langcode: en
+status: true
+dependencies:
+  config:
+    - key.key.tfa
+  module:
+    - real_aes
+_core:
+  default_config_hash: lDV_LbRGbNBnnVa6X72NK7xH7A1T9tasNNgP2hOhHKs
+id: real_aes
+label: 'Real AES'
+encryption_method: real_aes
+encryption_key: tfa
+encryption_method_configuration: {  }

--- a/conf/cmi/encrypt.settings.yml
+++ b/conf/cmi/encrypt.settings.yml
@@ -1,0 +1,4 @@
+_core:
+  default_config_hash: CMyccvAuba2yH-HYmcEL0pq1Seyxzq9VHhKbQKwAWY4
+check_profile_status: true
+allow_deprecated_plugins: false

--- a/conf/cmi/key.key.tfa.yml
+++ b/conf/cmi/key.key.tfa.yml
@@ -1,0 +1,19 @@
+uuid: 05f354f6-4d19-4cb0-9d95-0d16a1573e58
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: ARfRhKTJUSFXqKkDFwUncBUg8-5v7z_we3DETbYMYB0
+id: tfa
+label: TFA
+description: ''
+key_type: encryption
+key_type_settings:
+  key_size: 256
+key_provider: config
+key_provider_settings:
+  key_value: thisvaluewillbeoverridden1234567
+  base64_encoded: true
+key_input: text_field
+key_input_settings:
+  base64_encoded: false

--- a/conf/cmi/language/fi/key.key.tfa.yml
+++ b/conf/cmi/language/fi/key.key.tfa.yml
@@ -1,0 +1,1 @@
+label: 'Kaksivaiheinen tunnistautuminen (2FA)'

--- a/conf/cmi/language/fi/tfa.settings.yml
+++ b/conf/cmi/language/fi/tfa.settings.yml
@@ -1,0 +1,6 @@
+help_text: 'Ota yhteyttä tukeen palauttaaksesi tunnuksesi käyttöön'
+mail:
+  tfa_enabled_configuration:
+    body: "[user:display-name],\r\n\r\nThanks for configuring two-factor authentication on your [site:name] account!\r\n\r\nThis additional level of security will help to ensure that only you are able to log in to your account.\r\n\r\nIf you ever lose the device you configured, you should act quickly to delete its association with this account.\r\n\r\n--\r\n[site:name] team"
+  tfa_disabled_configuration:
+    body: "[user:display-name],\r\n\r\nTwo-factor authentication has been disabled on your [site:name] account.\r\n\r\nIf you did not take this action, please contact a site administrator immediately.\r\n\r\n--\r\n[site:name] team"

--- a/conf/cmi/language/sv/tfa.settings.yml
+++ b/conf/cmi/language/sv/tfa.settings.yml
@@ -1,0 +1,26 @@
+help_text: 'Kontakta supporten för att återställa din åtkomst'
+mail:
+  tfa_enabled_configuration:
+    subject: 'Ditt [site:name]-konto har nu tvåfaktorsautentisering'
+    body: |-
+      [user:display-name],
+
+      Tack för att du konfigurerade tvåfaktorsautentisering på ditt [site:name]konto!
+
+      Denna extra nivå av säkerhet hjälper till att säkerställa att enbart du kan logga in på ditt konto.
+
+      Om du någonsin förlorar den enhet som du konfigurerat detta med så bör du genast ta bort kopplingen till detta konto.
+
+      --
+      [site:name] teamet
+  tfa_disabled_configuration:
+    subject: 'Ditt [site:name] konto har inte längre tvåfaktorsautentisering'
+    body: |-
+      [user:display-name],
+
+      Tvåfaktorsautentisering har stängts av på ditt [site:name] konto.
+
+      Var vänlig och kontakta en administratör ifall det inte vara du som gjorde detta.
+
+      --
+      [site:name] teamet

--- a/conf/cmi/tfa.settings.yml
+++ b/conf/cmi/tfa.settings.yml
@@ -1,0 +1,50 @@
+_core:
+  default_config_hash: JyIkFj38h-aTLsrCfejAfP277qBJ61tlaLEBH44IHhg
+langcode: en
+enabled: true
+required_roles:
+  content_producer: content_producer
+  editor: editor
+  admin: admin
+  super_administrator: super_administrator
+  survey_editor: survey_editor
+  authenticated: '0'
+  read_only: '0'
+send_plugins: {  }
+login_plugins: {  }
+login_plugin_settings:
+  tfa_trusted_browser:
+    cookie_allow_subdomains: true
+    cookie_expiration: 30
+    cookie_name: tfa-trusted-browser
+allowed_validation_plugins:
+  tfa_totp: tfa_totp
+default_validation_plugin: tfa_totp
+validation_plugin_settings:
+  tfa_recovery_code:
+    recovery_codes_amount: 10
+  tfa_hotp:
+    counter_window: 10
+    site_name_prefix: 1
+    name_prefix: TFA
+    issuer: Drupal
+  tfa_totp:
+    time_skew: 2
+    site_name_prefix: 1
+    name_prefix: TFA
+    issuer: Hel.fi
+validation_skip: 3
+users_without_tfa_redirect: false
+reset_pass_skip_enabled: true
+encryption: real_aes
+tfa_flood_uid_only: 1
+tfa_flood_window: 300
+tfa_flood_threshold: 6
+help_text: 'Contact support to reset your access'
+mail:
+  tfa_enabled_configuration:
+    subject: 'Your [site:name] account now has two-factor authentication'
+    body: "[user:display-name],\r\n\r\nThanks for configuring two-factor authentication on your [site:name] account!\r\n\r\nThis additional level of security will help to ensure that only you are able to log in to your account.\r\n\r\nIf you ever lose the device you configured, you should act quickly to delete its association with this account.\r\n\r\n--\r\n[site:name] team"
+  tfa_disabled_configuration:
+    subject: 'Your [site:name] account no longer has two-factor authentication'
+    body: "[user:display-name],\r\n\r\nTwo-factor authentication has been disabled on your [site:name] account.\r\n\r\nIf you did not take this action, please contact a site administrator immediately.\r\n\r\n--\r\n[site:name] team"

--- a/conf/cmi/user.role.admin.yml
+++ b/conf/cmi/user.role.admin.yml
@@ -46,6 +46,7 @@ dependencies:
     - simple_sitemap
     - system
     - taxonomy
+    - tfa
     - view_unpublished
 _core:
   default_config_hash: dKoMlS2I78xz3dRwDh7nlvZPJM1CmU8s6tNswGPk3_4
@@ -132,6 +133,7 @@ permissions:
   - 'delete terms in news_group'
   - 'delete terms in news_neighbourhoods'
   - 'delete terms in news_tags'
+  - 'disable own tfa'
   - 'display eu cookie compliance popup'
   - 'edit any announcement content'
   - 'edit any file media'
@@ -167,6 +169,7 @@ permissions:
   - 'set landing_page published on date'
   - 'set news_item published on date'
   - 'set page published on date'
+  - 'setup own tfa'
   - 'translate announcement node'
   - 'translate any entity'
   - 'translate configuration'

--- a/conf/cmi/user.role.content_producer.yml
+++ b/conf/cmi/user.role.content_producer.yml
@@ -32,6 +32,7 @@ dependencies:
     - scheduler
     - system
     - taxonomy
+    - tfa
     - view_unpublished
 _core:
   default_config_hash: Et-md8KGvaWbSe-eFo52cwzavPsHfOxAALCFUM6WrHo
@@ -74,6 +75,7 @@ permissions:
   - 'delete own news_item content'
   - 'delete own page content'
   - 'delete own remote_video media'
+  - 'disable own tfa'
   - 'display eu cookie compliance popup'
   - 'edit any announcement content'
   - 'edit any file media'
@@ -103,6 +105,7 @@ permissions:
   - 'set landing_page published on date'
   - 'set news_item published on date'
   - 'set page published on date'
+  - 'setup own tfa'
   - 'translate editable entities'
   - 'translate file media'
   - 'translate image media'

--- a/conf/cmi/user.role.editor.yml
+++ b/conf/cmi/user.role.editor.yml
@@ -38,6 +38,7 @@ dependencies:
     - scheduler
     - system
     - taxonomy
+    - tfa
     - view_unpublished
 _core:
   default_config_hash: TrjtO2wskj94-mS9Sjjcao6G0hxATLPV3mK_2iCtX6k
@@ -102,6 +103,7 @@ permissions:
   - 'delete own remote_video media'
   - 'delete page revisions'
   - 'delete remote entities'
+  - 'disable own tfa'
   - 'display eu cookie compliance popup'
   - 'edit any announcement content'
   - 'edit any file media'
@@ -132,6 +134,7 @@ permissions:
   - 'set landing_page published on date'
   - 'set news_item published on date'
   - 'set page published on date'
+  - 'setup own tfa'
   - 'translate announcement node'
   - 'translate any entity'
   - 'translate editable entities'

--- a/conf/cmi/user.role.read_only.yml
+++ b/conf/cmi/user.role.read_only.yml
@@ -12,6 +12,7 @@ dependencies:
     - file
     - node
     - paragraphs
+    - tfa
     - view_unpublished
 _core:
   default_config_hash: z8aH8wuW8ZP68Aj6LO5ctNdfjlC137wZBJNVLPAZxS4
@@ -21,7 +22,9 @@ weight: 2
 is_admin: null
 permissions:
   - 'delete own files'
+  - 'disable own tfa'
   - 'display eu cookie compliance popup'
+  - 'setup own tfa'
   - 'view any unpublished announcement content'
   - 'view any unpublished landing_page content'
   - 'view any unpublished news_item content'

--- a/conf/cmi/user.role.read_only.yml
+++ b/conf/cmi/user.role.read_only.yml
@@ -12,7 +12,6 @@ dependencies:
     - file
     - node
     - paragraphs
-    - tfa
     - view_unpublished
 _core:
   default_config_hash: z8aH8wuW8ZP68Aj6LO5ctNdfjlC137wZBJNVLPAZxS4
@@ -22,9 +21,7 @@ weight: 2
 is_admin: null
 permissions:
   - 'delete own files'
-  - 'disable own tfa'
   - 'display eu cookie compliance popup'
-  - 'setup own tfa'
   - 'view any unpublished announcement content'
   - 'view any unpublished landing_page content'
   - 'view any unpublished news_item content'

--- a/conf/cmi/user.role.survey_editor.yml
+++ b/conf/cmi/user.role.survey_editor.yml
@@ -8,6 +8,7 @@ dependencies:
     - content_translation
     - node
     - publication_date
+    - tfa
 _core:
   default_config_hash: CliaTgzCQcvNF9ot3u_EbHnydymXh8bvNgNFlSffj9s
 id: survey_editor
@@ -19,9 +20,11 @@ permissions:
   - 'delete any survey content'
   - 'delete own survey content'
   - 'delete survey revisions'
+  - 'disable own tfa'
   - 'edit any survey content'
   - 'edit own survey content'
   - 'revert survey revisions'
   - 'set survey published on date'
+  - 'setup own tfa'
   - 'translate survey node'
   - 'view survey revisions'


### PR DESCRIPTION
# [UHF-10521](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10521)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Enable helfi_tfa module and its requirements.
* Export default settings.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10521`
* Set up the TFA key locally: Basically you need to generate the TFA-key and add it to the local.settings.php but you can find more detailed [instructions here](https://github.com/City-of-Helsinki/drupal-helfi-platform-config/blob/main/modules/helfi_tfa/README.md).
* Run `make drush-updb && make drush-cim`
* Run `make drush-locale-update` to get all translations for the module
* Run `make drush-cr`

## How to test
* [x] Login with `make drush-uli`. You shouldn't get a TFA warning for the UID1 user.
  * [x] Edit the UID1 account to make sure it has the super administrator role: https://emergency-site.docker.so/fi/user/1/edit
* [x] Create a new user with a content producer role and one with read-only user role.
* [x] Login with the content producer account and setup the TFA application. This process should work without any errors.
* [x] Login with the read-only user. You should not get the warning about TFA being mandatory.
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation. The instance is using the same setup as other instances.


[UHF-10521]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ