### PR TITLE
UHF-12404: Enable user delete feature

### DIFF
--- a/conf/cmi/helfi_api_base.features.yml
+++ b/conf/cmi/helfi_api_base.features.yml
@@ -1,4 +1,5 @@
 disable_email_sending: true
 disable_user_password: true
 user_expire: false
+user_delete: true
 use_mock_responses: false


### PR DESCRIPTION
# [UHF-12404](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12404)

## What was done

Split the user_expire feature flag into two independent toggles: user_expire (blocking inactive users after 6 months) and user_delete (deleting inactive users after 5 years)     
                                                 
## How to install                                                                                                                                                                    

<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your emergency-site is up and running on latest dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Update the Helfi API Base module
  * `composer require drupal/helfi_api_base:dev-UHF-12404
* Run code updates
  * `composer install`
  * `make drush-updb`

## How to test
                                                                                                                                                                            
* [x] Pick a test user (e.g. uid 7) and set its last access and changed time to 6 years ago:                                                                                    
  * Run: `drush sqlq "UPDATE users_field_data SET access = UNIX_TIMESTAMP() - 189216000, changed = UNIX_TIMESTAMP() - 189216000 WHERE uid = 7"`
  * Run: `drush cron`
* [x] Verify user is deleted: `drush sqlq "SELECT uid FROM users_field_data WHERE uid = 7"` (should return empty)                                                                 
* [x] Check that the code follows our standards 

[UHF-12404]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ